### PR TITLE
尝试解决试行后第一次反应的潜时记录常为0的问题

### DIFF
--- a/GB.py
+++ b/GB.py
@@ -56,6 +56,7 @@ leverActData = [] # 目標行動とその種類を表記（例えばFI10に10s�
 leverData = [] # 押されたレバーは左か右かを記録
 latencyData = [] # 潜時リストを記録
 timeData = [] # 反応時間を記録
+randomData = [] # 報酬種類を表す乱数を記録
 
 dataTransfer = [] # 行列変換用リスト
 
@@ -86,28 +87,34 @@ def protect():
 
 def chickenDinner():
     for i in range(9):
-        GPIO.output(buzzer, GPIO.LOW)
-        sleep(0.15)
         GPIO.output(buzzer, GPIO.HIGH)
+        sleep(0.15)
+        GPIO.output(buzzer, GPIO.LOW)
         sleep(0.15)
     pass
 
 def reinforce(rewardKind): # sReward/mReward/lReward
     for i in range(rewardKind):
         GPIO.output(feeder, GPIO.LOW)
-        GPIO.output(buzzer, GPIO.LOW)
+        GPIO.output(buzzer, GPIO.HIGH)
         sleep(0.5)
         GPIO.output(feeder, GPIO.HIGH)
-        GPIO.output(buzzer, GPIO.HIGH)
+        GPIO.output(buzzer, GPIO.LOW)
         sleep(0.5)
     pass
 
 def dataSaving():
-    dataTransfer = [leverPressData, leverData, timeData, leverActData, latencyData]
+    # データを保存
+    dataTransfer = [leverPressData, leverData, timeData, leverActData, latencyData, randomData]
     dataTransfer = list(zip(*dataTransfer))
     with open(answer2 + '.csv', 'a+') as myfile:
         writer = csv.writer(myfile)
         writer.writerows(dataTransfer)
+    # 生成された乱数列を保存
+    randomList = list(zip(*myList))
+    with open(answer2 + '_randomList.csv', 'a+') as myfile2:
+        writer = csv.writer(myfile2)
+        writer.writerow(randomList)
     pass
 
 def bye():
@@ -120,6 +127,7 @@ def bye():
 for i in range(1000):
     leverActData.append('')
     latencyData.append('')
+    randomData.append('')
     pass
 
 # 乱数生成
@@ -174,17 +182,17 @@ timeLatency = 0
 timeTrial = time.time()
 #day = time.strftime("%Y-%m-%d")
 
-headers = ['Trial', 'LeverSide', 'Time', 'SideCounter', 'Latency']
+headers = ['Counter', 'LeverSide', 'Time', 'Trial', 'Latency', 'Big/Small']
 with open(answer2 + '.csv', 'a+') as myfile:
     writer = csv.writer(myfile)
     writer.writerow(headers)
 
 # ポート初期化
-GPIO.output(buzzer, GPIO.HIGH)
+GPIO.output(buzzer, GPIO.LOW)
 GPIO.output(feeder, GPIO.HIGH)
 GPIO.output(leverLeftMove, GPIO.LOW)
 GPIO.output(leverRightMove, GPIO.LOW)
-GPIO.output(houseLight, GPIO.LOW)
+GPIO.output(houseLight, GPIO.HIGH)
 
 # メインプログラム
 try:
@@ -242,7 +250,7 @@ try:
             
 
         # FRを達成したら：
-        if ((trial < 2 or trial >= 4) and leftRight == 'left'): # 固定報酬選択肢
+        if leftRight == 'left': # 固定報酬選択肢
             if react == x:
                 leverIn()
                 react = 0
@@ -268,8 +276,8 @@ try:
                 timeTrial = time.time()
 
 
-        elif (leftRight == 'right' and trial >= 2): #変動報酬選択肢
-            if (react == x):
+        elif leftRight == 'right': #変動報酬選択肢
+            if react == x:
                 leverIn()
                 react = 0
                 # 強化
@@ -284,6 +292,7 @@ try:
                 trial = trial + 1
                 leverRightTrial = leverRightTrial + 1
                 leverActData.insert(leverPressCounter - 1, leverRightTrial)
+                randomData.insert(leverPressCounter - 1 , reinforcers)
                 # モニターに表せ
                 print("変動報酬", leverRightTrial)
                 print("timePast ", timePast)

--- a/GB.py
+++ b/GB.py
@@ -189,7 +189,7 @@ GPIO.output(houseLight, GPIO.LOW)
 # メインプログラム
 try:
     while timeNow - timeStart < timeMax:
-        timeNow = time.time()
+        # timeNow = time.time()
 
         # レバー押しを測る
         if reactLeft == x or reactRight == x:
@@ -264,6 +264,7 @@ try:
                 # レバー引き込みとITI
                 sleep(iti)
                 leverOut()
+                protect()
                 timeTrial = time.time()
 
 
@@ -298,6 +299,7 @@ try:
                 reinforceYN = 0
                 sleep(iti)
                 leverOut()
+                protect()
                 timeTrial = time.time()
                 pass
             else:
@@ -308,6 +310,7 @@ try:
                 reinforcers = 0
                 sleep(iti)
                 leverOut()
+                protect()
                 timeTrial = time.time()
                 
         # 最大試行数になったか否か

--- a/semiGB.py
+++ b/semiGB.py
@@ -56,6 +56,7 @@ leverActData = [] # 目標行動とその種類を表記（例えばFI10に10s�
 leverData = [] # 押されたレバーは左か右かを記録
 latencyData = [] # 潜時リストを記録
 timeData = [] # 反応時間を記録
+randomData = []
 
 dataTransfer = [] # 行列変換用リスト
 
@@ -87,27 +88,33 @@ def protect():
 def reinforce(rewardKind): # sReward/mReward/lReward
     for i in range(rewardKind):
         GPIO.output(feeder, GPIO.LOW)
-        GPIO.output(buzzer, GPIO.LOW)
+        GPIO.output(buzzer, GPIO.HIGH)
         sleep(0.5)
         GPIO.output(feeder, GPIO.HIGH)
-        GPIO.output(buzzer, GPIO.HIGH)
+        GPIO.output(buzzer, GPIO.LOW)
         sleep(0.5)
     pass
 
 def chickenDinner():
     for i in range(9):
-        GPIO.output(buzzer, GPIO.LOW)
-        sleep(0.15)
         GPIO.output(buzzer, GPIO.HIGH)
+        sleep(0.15)
+        GPIO.output(buzzer, GPIO.LOW)
         sleep(0.15)
     pass
 
 def dataSaving():
-    dataTransfer = [leverPressData, leverData, timeData, leverActData, latencyData]
+    # データを保存
+    dataTransfer = [leverPressData, leverData, timeData, leverActData, latencyData, randomData]
     dataTransfer = list(zip(*dataTransfer))
     with open(answer2 + '.csv', 'a+') as myfile:
         writer = csv.writer(myfile)
         writer.writerows(dataTransfer)
+    # 生成された乱数列を保存
+    randomList = list(zip(*myList))
+    with open(answer2 + '_randomList.csv', 'a+') as myfile2:
+        writer = csv.writer(myfile2)
+        writer.writerow(randomList)
     pass
 
 def bye():
@@ -120,6 +127,7 @@ def bye():
 for i in range(1000):
     leverActData.append('')
     latencyData.append('')
+    randomData.append('')
     pass
 
 # 乱数生成
@@ -174,18 +182,18 @@ timeLatency = 0
 timeTrial = time.time()
 #day = time.strftime("%Y-%m-%d")
 
-headers = ['Trial', 'LeverSide', 'Time', 'SideCounter', 'Latency']
+headers = ['Counter', 'LeverSide', 'Time', 'Trial', 'Latency', 'Big/Small']
 with open(answer2 + '.csv', 'a+') as myfile:
     writer = csv.writer(myfile)
     writer.writerow(headers)
 
 
 # ポート初期化
-GPIO.output(buzzer, GPIO.HIGH)
+GPIO.output(buzzer, GPIO.LOW)
 GPIO.output(feeder, GPIO.HIGH)
 GPIO.output(leverLeftMove, GPIO.LOW)
 GPIO.output(leverRightMove, GPIO.LOW)
-GPIO.output(houseLight, GPIO.LOW)
+GPIO.output(houseLight, GPIO.HIGH)
 
 # メインプログラム
 try:
@@ -243,7 +251,7 @@ try:
             
 
         # FRを達成したら：
-        if ((trial < 2 or trial >= 4) and leftRight == 'left'): # 固定報酬選択肢
+        if leftRight == 'left': # 固定報酬選択肢
             if react == x:
                 leverIn()
                 react = 0
@@ -269,8 +277,8 @@ try:
                 timeTrial = time.time()
 
 
-        elif (leftRight == 'right' and trial >= 2): #変動報酬選択肢
-            if (react == x):
+        elif leftRight == 'right': #変動報酬選択肢
+            if react == x:
                 leverIn()
                 react = 0
                 # 強化
@@ -285,6 +293,7 @@ try:
                 trial = trial + 1
                 leverRightTrial = leverRightTrial + 1
                 leverActData.insert(leverPressCounter - 1, leverRightTrial)
+                randomData.insert(leverPressCounter - 1, reinforcers)
                 # モニターに表せ
                 print("変動報酬", leverRightTrial)
                 print("timePast ", timePast)

--- a/semiGB.py
+++ b/semiGB.py
@@ -190,7 +190,7 @@ GPIO.output(houseLight, GPIO.LOW)
 # メインプログラム
 try:
     while timeNow - timeStart < timeMax:
-        timeNow = time.time()
+        # timeNow = time.time()
 
         # レバー押しを測る
         if reactLeft == x or reactRight == x:
@@ -265,6 +265,7 @@ try:
                 # レバー引き込みとITI
                 sleep(iti)
                 leverOut()
+                protect()
                 timeTrial = time.time()
 
 
@@ -299,6 +300,7 @@ try:
                 reinforceYN = 0
                 sleep(iti)
                 leverOut()
+                protect()
                 timeTrial = time.time()
                 pass
             else:
@@ -309,6 +311,7 @@ try:
                 reinforcers = 0
                 sleep(iti)
                 leverOut()
+                protect()
                 timeTrial = time.time()
                 
         # 最大試行数になったか否か


### PR DESCRIPTION
从前四次的实验记录中可以看到：ITI后的第一次反应的潜时常被记录为0
*  GB和semiGB中均有出现
*  在固定强化和选择强化中均有出现（但常常前几次没事）
--  是不是和While大循环下的timeNow有关？   否定
--  是不是和有的脚本中timeLatency没从insert变成append有关？  否定
*  设备试验台上正常
--  如果ITI中一直按着，则有一上来就为零的情况
--  本次的尝试解决方法：
---  在所有的 leverOut() 之后加上 protect()